### PR TITLE
create output function with wrong path erased

### DIFF
--- a/rmtk/vulnerability/common/utils.py
+++ b/rmtk/vulnerability/common/utils.py
@@ -1013,17 +1013,6 @@ def plot_fragility_model(fragility_model, minIML, maxIML):
         plt.legend(loc=4)
     plt.show()
 
-
-def create_fragility_out_files(fragility_model, output_type):
-    path = '../../../../../rmtk_data/output'
-    out2 = 'fragility_output.csv'
-    out_file = open(os.path.join(path, out2), 'w')
-    [fragility_model_converted, outputs] = output_conversions(fragility_model, output_type)
-    out_file.write('Damage State, %s, %s \n' %(outputs[0], outputs[1]))
-    for iDS in range(len(fragility_model)):
-        out_file.write('%s, %f, %f \n' %(fragility_model_converted[iDS][1], fragility_model_converted[iDS][0][0], fragility_model_converted[iDS][0][1]))
-    out_file.close()
-
 def output_conversions(fragility_model, output_type):
     fragility_model_converted = []
 


### PR DESCRIPTION
This PR solves #25 issue. The function is not used anymore in the rmtk and it has been erased
