### PR TITLE
bugs in check consequence function, description in record-based methods

### DIFF
--- a/rmtk/vulnerability/common/utils.py
+++ b/rmtk/vulnerability/common/utils.py
@@ -1457,18 +1457,15 @@ def read_consequence_model(input_file):
 def convert_fragility_vulnerability(fragility_model, cons_model, imls, dist_type):
 
     vulnerability_model = []
-    if check_damage_states(fragility_model, cons_model):
-        no_samples = 100
-        loss_ratios = []
-        for isample in range(no_samples):
-            loss_ratios.append(sample_loss_ratios(fragility_model, cons_model, imls))
+    check_damage_states(fragility_model, cons_model)
+    no_samples = 100
+    loss_ratios = []
+    for isample in range(no_samples):
+        loss_ratios.append(sample_loss_ratios(fragility_model, cons_model, imls))
     if dist_type == 'lognormal' or dist_type == 'beta':
         vulnerability_model = create_parametric_vul_model(imls, loss_ratios, dist_type, fragility_model['IMT'])
     elif dist_type == 'PMF':
         vulnerability_model = create_nonparametric_vul_model(imls, loss_ratios, dist_type, fragility_model['IMT'])
-
-    else:
-        print 'The fragility model and the consequence model are not compatible.'
 
     return vulnerability_model
 
@@ -1547,12 +1544,10 @@ def plot_vulnerability_model(vulnerability_model):
 
 def check_damage_states(model1, model2):
 
-    result = True
     for iDS in range(len(model1['damage_states'])):
-        if model1['damage_states'][iDS] !=  model2['damage_states'][iDS]:
-            result = False
+        assert(model1['damage_states'][iDS] ==  model2['damage_states'][iDS]), 'The fragility model and the consequence model are not compatible'
 
-    return result
+    return
 
 def sample_loss_ratios(fragility_model, cons_model, imls):
 

--- a/rmtk/vulnerability/derivation_fragility/derivation_fragility.ipynb
+++ b/rmtk/vulnerability/derivation_fragility/derivation_fragility.ipynb
@@ -24,7 +24,7 @@
     "---\n",
     "## 1 — Direct Nonlinear Static Procedures\n",
     "\n",
-    "These methodologies estimate the median seismic intensity values corresponding to the attainment of the damage state of interest, taking into account record-to-record dispersion and dispersion in the damage state thresholds. The inelastic displacements are estimated from the maximum elastic displacements by means of an $R-\\mu-T$ relationship.\n",
+    "These methodologies estimate the median seismic intensity values corresponding to the attainment of the damage state of interest, taking into account record-to-record dispersion and dispersion in the damage state thresholds. The inelastic displacements are estimated from the maximum elastic displacements by means of pre-computed $R-\\mu-T$ relationships.\n",
     "\n",
     "### 1.1 - SPO2IDA (2006)\n",
     "This methodology uses the SPO2IDA tool (Vamvatsikos and Cornell, 2006) to convert static pushover curves into $16\\%$, $50\\%$, and $84\\%$ IDA curves. The procedure is applicable to any kind of multi-linear capacity curve and it is suitable for single-building fragility curve estimation. Individual fragility curves can later be combined into a single fragility curve that considers the inter-building uncertainty. To use this feature click [here](../../../rmtk/vulnerability/derivation_fragility/R_mu_T_dispersion/SPO2IDA/spo2ida.ipynb).\n",
@@ -42,7 +42,7 @@
    "source": [
     "---\n",
     "## 2 — Record-based Nonlinear Static Procedures\n",
-    "Equivalent linearization methods allow to estimate a demand spectrum that can properly take into account the inelastic behaviour of the structures under analysis, namely, their capacity of dissipating energy through hysteresis (Monteiro, 2011). This can be achieved either by the use of modification factors or by considering an equivalent linear system.\n",
+    "Record-based Nonlinear Static Procedures allow the User to use its own set of accelograms and estimate for each of them the inelastic target displacement of the structure (Monteiro, 2011). This can be achieved either multiplying the elastic spectral displacement by a displacement modification factor or by considering an equivalent linear system.\n",
     "\n",
     "### 2.1 - Vidic, Fajfar and Fischinger (1994)\n",
     "This procedure aims to determine the displacements from an inelastic design spectra for systems with a given ductility factor. The inelastic displacement spectra is determined by means of applying a reduction factor, which depends on the natural period of the system, its ductility factor, the hysteretic behaviour, the damping, and the frequency content of the ground motion. To use this feature click [here](../../../rmtk/vulnerability/derivation_fragility/equivalent_linearization/vidic_etal_1994/vidic_etal_1994.ipynb).\n",

--- a/rmtk/vulnerability/derivation_fragility/derivation_fragility.ipynb
+++ b/rmtk/vulnerability/derivation_fragility/derivation_fragility.ipynb
@@ -42,7 +42,7 @@
    "source": [
     "---\n",
     "## 2 — Record-based Nonlinear Static Procedures\n",
-    "Record-based Nonlinear Static Procedures allow the User to use its own set of accelograms and estimate for each of them the inelastic target displacement of the structure (Monteiro, 2011). This can be achieved either multiplying the elastic spectral displacement by a displacement modification factor or by considering an equivalent linear system.\n",
+    "Record-based Nonlinear Static Procedures allow the User to input its own set of accelograms and estimate for each of them the inelastic target displacement of the structure. This can be achieved either multiplying the elastic spectral displacement by a displacement modification factor or by considering an equivalent linear system.\n",
     "\n",
     "### 2.1 - Vidic, Fajfar and Fischinger (1994)\n",
     "This procedure aims to determine the displacements from an inelastic design spectra for systems with a given ductility factor. The inelastic displacement spectra is determined by means of applying a reduction factor, which depends on the natural period of the system, its ductility factor, the hysteretic behaviour, the damping, and the frequency content of the ground motion. To use this feature click [here](../../../rmtk/vulnerability/derivation_fragility/equivalent_linearization/vidic_etal_1994/vidic_etal_1994.ipynb).\n",


### PR DESCRIPTION
utils.convert_fragility_vulnerability is now raising an error if the damage model and consequence model are incompatible. This commit solves #73 Issue.
Description of record-based NSPs improved.
