### PR TITLE
Update N2Method.py

### DIFF
--- a/rmtk/vulnerability/derivation_fragility/hybrid_methods/N2/N2Method.py
+++ b/rmtk/vulnerability/derivation_fragility/hybrid_methods/N2/N2Method.py
@@ -40,6 +40,7 @@ def calculate_target_Sd(gmrs,igmr,capacity_curves,icc,damping):
     
     spec_Ty = utils.NigamJennings(time,acc,[Ty],damping)
     demand_Sd_Ty = spec_Ty['Sd']
+    demand_Sa_Ty = spec_Ty['Sa']
     spec_10sec = utils.NigamJennings(time,acc,[1.0],damping) 
     spec_03sec = utils.NigamJennings(time,acc,[0.3],damping) 
     Tc = spec_10sec['Sa']/spec_03sec['Sa'];
@@ -51,7 +52,7 @@ def calculate_target_Sd(gmrs,igmr,capacity_curves,icc,damping):
             Sdi = spectrum['Sd']
         
         else:
-            qu=demand_Sd_Ty/Say
+            qu=demand_Sa_Ty/Say
             Sdi = max([demand_Sd_Ty/qu*(1+(qu-1)*Tc/Ty),demand_Sd_Ty])
             if Sdi > 3*demand_Sd_Ty:
                 Sdi = demand_Sd_Ty


### PR DESCRIPTION
1 - Bug in definition of parameter q (elastic acceleration demand at yielding Sa,e(Ty) over yielding strength Say) in N2 method 
q=Sa,e(Ty)/Say
According to Fajfar [2000] 

2- The modification for Sdi > 3*demand_Sd_Ty  at line 57 and 58, this is not present in the original paper

Fajfar [2000] "a nonlinear analysis method for performance based seismic design", Earthquake Spectra, 16(3), http://30let.ikpir.com/data/bibliografije/att/1085537.fulltext.pdf
