### PR TITLE
Do not silently fail if OpenSees does not run properly

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,9 +16,13 @@ WORKDIR ${HOME}
 
 ADD https://api.github.com/repos/$repo/rmtk/git/refs/heads/$branch /tmp/nocache.json
 
-RUN wget -q https://github.com/$repo/rmtk/archive/$branch.tar.gz && \
+RUN echo "Downloading RMTK" && \
+    wget -q https://github.com/$repo/rmtk/archive/$branch.tar.gz && \
+    echo "Extracting RMTK" && \
     tar xzf $branch.tar.gz && mv rmtk-$branch rmtk && rm $branch.tar.gz
-RUN wget -q https://github.com/$repo/rmtk_data/archive/master.tar.gz && \
+RUN echo "Downloading RMTK-DATA" && \
+    wget -q https://github.com/$repo/rmtk_data/archive/master.tar.gz && \
+    echo "Extracting RMTK-DATA" && \
     tar xzf master.tar.gz && mv rmtk_data-master rmtk_data && rm master.tar.gz
 
 RUN virtualenv ${HOME}/venv

--- a/rmtk/vulnerability/derivation_fragility/NLTHA_on_SDOF/MSA_on_SDOF.py
+++ b/rmtk/vulnerability/derivation_fragility/NLTHA_on_SDOF/MSA_on_SDOF.py
@@ -98,7 +98,7 @@ def run_time_history_analysis(capacity_curves, hysteresis, icc, gmrs,
                          "OpenSees.u1604"), tcl],
                          cwd=package_directory, stderr=STDOUT)
         else:
-            sys.exit('Your OS is not curently support')
+            sys.exit('Your OS is not currently support')
     except CalledProcessError as e:
         print(e.output)
         raise

--- a/rmtk/vulnerability/derivation_fragility/NLTHA_on_SDOF/MSA_on_SDOF.py
+++ b/rmtk/vulnerability/derivation_fragility/NLTHA_on_SDOF/MSA_on_SDOF.py
@@ -4,6 +4,9 @@ import sys
 import subprocess
 import csv
 import numpy
+
+from subprocess import STDOUT, check_output, CalledProcessError
+
 from rmtk import __file__ as rmtk_path
 from rmtk.vulnerability.common import utils
 
@@ -85,14 +88,20 @@ def run_time_history_analysis(capacity_curves, hysteresis, icc, gmrs,
 
     tcl = os.path.join(package_directory, "simplestSDOFgen.tcl")
 
-    if 'darwin' in sys.platform:
-        subprocess.call([os.path.join(bin_directory, "OpenSees.mac"), tcl],
-                        cwd=package_directory)
-    elif 'linux' in sys.platform:
-        subprocess.call([os.path.join(bin_directory, "OpenSees.u1604"), tcl],
-                        cwd=package_directory)
-    else:
-        sys.exit('Your OS is not curently support')
+    try:
+        if 'darwin' in sys.platform:
+            check_output([os.path.join(bin_directory,
+                         "OpenSees.mac"), tcl],
+                         cwd=package_directory, stderr=STDOUT)
+        elif 'linux' in sys.platform:
+            check_output([os.path.join(bin_directory,
+                         "OpenSees.u1604"), tcl],
+                         cwd=package_directory, stderr=STDOUT)
+        else:
+            sys.exit('Your OS is not curently support')
+    except CalledProcessError as e:
+        print(e.output)
+        raise
 
     disps = []
     time = []

--- a/rmtk/vulnerability/derivation_fragility/NLTHA_on_SDOF/NLTHA_on_SDOF.py
+++ b/rmtk/vulnerability/derivation_fragility/NLTHA_on_SDOF/NLTHA_on_SDOF.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 import os
 import sys
-import subprocess
 import numpy
+
+from subprocess import STDOUT, check_output, CalledProcessError
+
 from rmtk import __file__ as rmtk_path
 from rmtk.vulnerability.common import utils
 
@@ -43,14 +45,20 @@ def run_time_history_analysis(capacity_curves, hysteresis, icc, gmrs, igmr,
 
     tcl = os.path.join(package_directory, "simplestSDOFgen.tcl")
 
-    if 'darwin' in sys.platform:
-        subprocess.call([os.path.join(bin_directory, "OpenSees.mac"), tcl],
-                        cwd=package_directory)
-    elif 'linux' in sys.platform:
-        subprocess.call([os.path.join(bin_directory, "OpenSees.u1604"), tcl],
-                        cwd=package_directory)
-    else:
-        sys.exit('Your OS is not curently support')
+    try:
+        if 'darwin' in sys.platform:
+            check_output([os.path.join(bin_directory,
+                         "OpenSees.mac"), tcl],
+                         cwd=package_directory, stderr=STDOUT)
+        elif 'linux' in sys.platform:
+            check_output([os.path.join(bin_directory,
+                         "OpenSees.u1604"), tcl],
+                         cwd=package_directory, stderr=STDOUT)
+        else:
+            sys.exit('Your OS is not curently support')
+    except CalledProcessError as e:
+        print(e.output)
+        raise
 
     disps = []
     time = []

--- a/rmtk/vulnerability/derivation_fragility/NLTHA_on_SDOF/NLTHA_on_SDOF.py
+++ b/rmtk/vulnerability/derivation_fragility/NLTHA_on_SDOF/NLTHA_on_SDOF.py
@@ -55,7 +55,7 @@ def run_time_history_analysis(capacity_curves, hysteresis, icc, gmrs, igmr,
                          "OpenSees.u1604"), tcl],
                          cwd=package_directory, stderr=STDOUT)
         else:
-            sys.exit('Your OS is not curently support')
+            sys.exit('Your OS is not currently support')
     except CalledProcessError as e:
         print(e.output)
         raise

--- a/rmtk/vulnerability/derivation_fragility/NLTHA_on_SDOF/double_MSA_on_SDOF.py
+++ b/rmtk/vulnerability/derivation_fragility/NLTHA_on_SDOF/double_MSA_on_SDOF.py
@@ -1,13 +1,15 @@
 # -*- coding: utf-8 -*-
 import os
-import subprocess
+import sys
 import csv
 import numpy
 import scipy
-from sys import platform
+
+from subprocess import STDOUT, check_output, CalledProcessError
+
 from rmtk.vulnerability.common import utils
 
-# DV: this file has too many problems, I gave up
+# DV: this file has too many problems, I give up
 
 def calculate_fragility(capacity_curves, hysteresis, msa, gmrs,gmr_characteristics,damage_model,damping,degradation,number_models_in_DS):
     
@@ -196,15 +198,19 @@ def run_time_history_analysis(capacity_curves, hysteresis, icc,gmrs,target_name,
     tcl = 'simplestSDOFgen.tcl'
 
     try:
-        subprocess.call(["OpenSees", tcl])
-    except OSError:
-        try:
-            if 'darwin' in platform:
-                subprocess.call(["../../../../bin/OpenSees.mac", tcl])
-            elif 'linux' in platform:
-                subprocess.call(["../../../../bin/OpenSees.u1604", tcl])
-        except:
-            raise OSError('OpenSees not found')
+        if 'darwin' in sys.platform:
+            check_output([os.path.join(bin_directory,
+                         "OpenSees.mac"), tcl],
+                         cwd=package_directory, stderr=STDOUT)
+        elif 'linux' in sys.platform:
+            check_output([os.path.join(bin_directory,
+                         "OpenSees.u1604"), tcl],
+                         cwd=package_directory, stderr=STDOUT)
+        else:
+            sys.exit('Your OS is not curently support')
+    except CalledProcessError as e:
+        print(e.output)
+        raise
 
     disps = []
     time = []

--- a/rmtk/vulnerability/derivation_fragility/NLTHA_on_SDOF/double_MSA_on_SDOF.py
+++ b/rmtk/vulnerability/derivation_fragility/NLTHA_on_SDOF/double_MSA_on_SDOF.py
@@ -207,7 +207,7 @@ def run_time_history_analysis(capacity_curves, hysteresis, icc,gmrs,target_name,
                          "OpenSees.u1604"), tcl],
                          cwd=package_directory, stderr=STDOUT)
         else:
-            sys.exit('Your OS is not curently support')
+            sys.exit('Your OS is not currently support')
     except CalledProcessError as e:
         print(e.output)
         raise


### PR DESCRIPTION
Now it reports the proper exception and error:

```bash

/home/daniele/GIT/gem/rmtk/rmtk/../bin/OpenSees.u1604: error while loading shared libraries: libgfortran.so.3: cannot open shared object file: No such file or directory

---------------------------------------------------------------------------
CalledProcessError                        Traceback (most recent call last)
<ipython-input-6-c7f96b51ca5c> in <module>()
      1 damping_ratio = 0.05
      2 degradation = True
----> 3 PDM, Sds = NLTHA_on_SDOF.calculate_fragility(capacity_curves, hysteresis, gmrs, damage_model, damping_ratio, degradation)
      4 utils.save_result(PDM,'../../../../../rmtk_data/PDM.csv')

/home/daniele/GIT/gem/rmtk/rmtk/vulnerability/derivation_fragility/NLTHA_on_SDOF/NLTHA_on_SDOF.py in calculate_fragility(capacity_curves, hysteresis, gmrs, damage_model, damping, degradation)
     31             time, disps = run_time_history_analysis(capacity_curves,
     32                                                     hysteresis, icc, gmrs,
---> 33                                                     igmr, damping, degradation)
     34             Sdi = max(numpy.abs(numpy.array(disps)))
     35             [PDM, ds] = utils.allocate_damage(igmr, PDM, Sdi, limit_states)

/home/daniele/GIT/gem/rmtk/rmtk/vulnerability/derivation_fragility/NLTHA_on_SDOF/NLTHA_on_SDOF.py in run_time_history_analysis(capacity_curves, hysteresis, icc, gmrs, igmr, damping, degradation)
     55             check_output([os.path.join(bin_directory,
     56                        "OpenSees.u1604"), tcl],
---> 57                        cwd=package_directory, stderr=STDOUT)
     58         else:
     59             sys.exit('Your OS is not curently support')

/usr/lib64/python2.7/subprocess.pyc in check_output(*popenargs, **kwargs)
    217         if cmd is None:
    218             cmd = popenargs[0]
--> 219         raise CalledProcessError(retcode, cmd, output=output)
    220     return output
    221 

CalledProcessError: Command '['/home/daniele/GIT/gem/rmtk/rmtk/../bin/OpenSees.u1604', '/home/daniele/GIT/gem/rmtk/rmtk/vulnerability/derivation_fragility/NLTHA_on_SDOF/simplestSDOFgen.tcl']' returned non-zero exit status 127
```

Previously unrelated errors, masking the real ones, were reported.